### PR TITLE
Removed location.protocol check

### DIFF
--- a/LiveChat/LiveChat.js
+++ b/LiveChat/LiveChat.js
@@ -30,7 +30,7 @@ export default class LiveChat extends React.Component {
       const lc = document.createElement('script');
       lc.type = 'text/javascript';
       lc.async = true;
-      lc.src = ('https:' === document.location.protocol ? 'https://' : 'http://') + 'cdn.livechatinc.com/tracking.js';
+      lc.src = '//cdn.livechatinc.com/tracking.js';
       const s = document.getElementsByTagName('script')[0];
       s.parentNode.insertBefore(lc, s);
       lc.addEventListener('load', this.chatLoaded.bind(this));


### PR DESCRIPTION
We have problems with this as we are pre-rendering pages of our site using http. So I removed the  location.protocol check as it looks like it's only needed for IE6.