### PR TITLE
Prefix componentWillMount with UNSAFE_

### DIFF
--- a/LiveChat/LiveChat.js
+++ b/LiveChat/LiveChat.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class LiveChat extends React.Component {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.loadLiveChatApi.bind(this)();
   }
 


### PR DESCRIPTION
https://github.com/livechat/react-livechat/pull/44 is a better, long term solution. This is a short term solution to reduce development warnings due to `componentWillMount` being marked as deprecated past React v16. 

[Link to React docs about deprecation](https://reactjs.org/docs/react-component.html#unsafe_componentwillmount)